### PR TITLE
feat: concat the global_parameter_path_prefix infront of all secret env vars

### DIFF
--- a/EXAMPLE.md
+++ b/EXAMPLE.md
@@ -27,8 +27,9 @@ module "ecs_task_definition" {
     TEST = "1"
     FOO = "BAR"
   }
+  parameter_path_prefix = "/project/env"
   secret_environment_variables = {
-    SECRET = "path/to/ssm/variable"
+    SECRET = "remaining_path/to/ssm/variable"
   }
   cloudwatch_log_retention_in_days = 30
 }

--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ No modules.
 | <a name="input_image"></a> [image](#input\_image) | ECR image | `string` | n/a | yes |
 | <a name="input_name"></a> [name](#input\_name) | ECS task definition name | `string` | n/a | yes |
 | <a name="input_network_mode"></a> [network\_mode](#input\_network\_mode) | Docker networking mode to use for the containers in the task. The valid values are none, bridge, awsvpc, and host. | `string` | `"awsvpc"` | no |
+| <a name="input_parameter_path_prefix"></a> [parameter\_path\_prefix](#input\_parameter\_path\_prefix) | Path prefix for SSM parameter | `string` | `""` | no |
 | <a name="input_port"></a> [port](#input\_port) | ECS container port | `number` | `0` | no |
 | <a name="input_requires_compatibilities"></a> [requires\_compatibilities](#input\_requires\_compatibilities) | A set of launch types required by the task. The valid values are EC2 and FARGATE. | `list(string)` | <pre>[<br>  "FARGATE"<br>]</pre> | no |
 | <a name="input_secret_environment_variables"></a> [secret\_environment\_variables](#input\_secret\_environment\_variables) | ECS secrets environment variables | `map(string)` | `{}` | no |

--- a/data.tf
+++ b/data.tf
@@ -24,7 +24,7 @@ locals {
   secret_environment_variables = flatten([
     for name, valueFrom in var.secret_environment_variables : {
       name      = name
-      valueFrom = "${var.parameter_path_prefix}${valueFrom}"
+      valueFrom = "${var.parameter_path_prefix}/${valueFrom}"
     }
   ])
 }

--- a/data.tf
+++ b/data.tf
@@ -24,7 +24,7 @@ locals {
   secret_environment_variables = flatten([
     for name, valueFrom in var.secret_environment_variables : {
       name      = name
-      valueFrom = valueFrom
+      valueFrom = "${var.parameter_path_prefix}${valueFrom}"
     }
   ])
 }

--- a/variables.tf
+++ b/variables.tf
@@ -13,6 +13,12 @@ variable "command" {
   default     = ""
 }
 
+variable "parameter_path_prefix" {
+  description = "Path prefix for SSM parameter"
+  type        = string
+  default     = ""
+}
+
 variable "image" {
   description = "ECR image"
   type        = string


### PR DESCRIPTION
Instead of repeatedly mentioning `global_parameter_path_prefix` in `secret_environment_variables` values, we can pass it only once as a variable and concatenate it with the values of 'secret_environment_variables' in the current module.

Example,
```
secret_environment_variables = {
    DB_DATABASE_NAME = "${var.global_parameter_path_prefix}/rds/default/db_name"
    DB_USERNAME            = "${var.global_parameter_path_prefix}/rds/default/db_username"
}
```

In the above example, we have passed `var.global_parameter_path_prefix` repeatedly, but from now we need to pass the `global_parameter_path_prefix` as a variable only and it will be concatinated with all the values, as shown in the below example.
```
global_parameter_path_prefix = var.global_parameter_path_prefix

secret_environment_variables = {
    DB_DATABASE_NAME = "/rds/default/db_name"
    DB_USERNAME            = "/rds/default/db_username"
}
```