### PR TITLE
feat: map ssm_path with ssm version and detect changes of ssm parameter store's version

### DIFF
--- a/data.tf
+++ b/data.tf
@@ -9,6 +9,22 @@ data "aws_kms_alias" "ssm" {
   name = var.ssm_kms_alias
 }
 
+data "aws_ssm_parameter" "ssm_secret" {
+  for_each = var.secret_environment_variables
+  name     = "${var.parameter_path_prefix}/${each.value}"
+}
+
+## Mapping : SSM path => version ( to detect the change in particular path's value)
+resource "null_resource" "ssm_version_check" {
+  triggers = {
+    ssm_versions = jsonencode(
+      {
+        for para in data.aws_ssm_parameter.ssm_secret : para.name => para.version
+      }
+    )
+  }
+}
+
 locals {
   aws_partition   = data.aws_partition.current.partition
   account_id      = data.aws_caller_identity.current.account_id
@@ -24,7 +40,7 @@ locals {
   secret_environment_variables = flatten([
     for name, valueFrom in var.secret_environment_variables : {
       name      = name
-      valueFrom = "${var.parameter_path_prefix}/${valueFrom}"
+      valueFrom = data.aws_ssm_parameter.ssm_secret[name].name
     }
   ])
 }

--- a/data.tf
+++ b/data.tf
@@ -9,17 +9,17 @@ data "aws_kms_alias" "ssm" {
   name = var.ssm_kms_alias
 }
 
-data "aws_ssm_parameter" "ssm_secret" {
+data "aws_ssm_parameter" "secret_env_vars" {
   for_each = var.secret_environment_variables
   name     = "${var.parameter_path_prefix}/${each.value}"
 }
 
-## Mapping : SSM path => version ( to detect the change in particular path's value)
-resource "null_resource" "ssm_version_check" {
+## Create map of "parameter_name => parameter_version" to detect the change of parameter's value
+resource "null_resource" "parameter_version_check" {
   triggers = {
     ssm_versions = jsonencode(
       {
-        for para in data.aws_ssm_parameter.ssm_secret : para.name => para.version
+        for parameter in data.aws_ssm_parameter.secret_env_vars : parameter.name => parameter.version
       }
     )
   }
@@ -40,7 +40,7 @@ locals {
   secret_environment_variables = flatten([
     for name, valueFrom in var.secret_environment_variables : {
       name      = name
-      valueFrom = data.aws_ssm_parameter.ssm_secret[name].name
+      valueFrom = data.aws_ssm_parameter.secret_env_vars[name].name
     }
   ])
 }

--- a/main.tf
+++ b/main.tf
@@ -46,7 +46,7 @@ resource "aws_ecs_task_definition" "task" {
   ## The resource will be restarted if null resource restarts 
   lifecycle {
     replace_triggered_by = [
-      null_resource.ssm_version_check
+      null_resource.parameter_version_check
     ]
   }
 }

--- a/main.tf
+++ b/main.tf
@@ -42,4 +42,11 @@ resource "aws_ecs_task_definition" "task" {
       }
     ]
   )
+
+  ## The resource will be restarted if null resource restarts 
+  lifecycle {
+    replace_triggered_by = [
+      null_resource.ssm_version_check
+    ]
+  }
 }


### PR DESCRIPTION
Creates a map of SSM parameter store `path => version`
If any changes occur in the version, the null resource will be recreated, and because of the null resource, the ECS task definition will be recreated